### PR TITLE
Use tuple for tradeoff costs consistently

### DIFF
--- a/src/GenerativeDesigns/GenerativeDesigns.jl
+++ b/src/GenerativeDesigns/GenerativeDesigns.jl
@@ -37,7 +37,7 @@ Evidence(p1::Pair, pairs::Pair...) = merge(Evidence(), Dict(p1, pairs...))
 """
 Represent experimental state as a tuple of experimental costs and evidence.
 """
-const State = NamedTuple{(:evidence, :costs),Tuple{Evidence,<:Vector{Real}}}
+const State = NamedTuple{(:evidence, :costs),Tuple{Evidence,NTuple{2,Float64}}}
 
 function Base.merge(state::State, evidence, costs)
     return State((merge(state.evidence, evidence), state.costs .+ costs))
@@ -46,9 +46,9 @@ end
 include("distancebased.jl")
 
 """
-Represent action as a named tuple `(; costs=[monetary cost, time], features)`.
+Represent action as a named tuple `(; costs=(monetary cost, time), features)`.
 """
-const ActionCost = NamedTuple{(:costs, :features),<:Tuple{Vector{Float64},Vector{String}}}
+const ActionCost = NamedTuple{(:costs, :features),<:Tuple{NTuple{2,Float64},Vector{String}}}
 
 const const_bigM = 1_000_000
 

--- a/src/GenerativeDesigns/UncertaintyReductionMDP.jl
+++ b/src/GenerativeDesigns/UncertaintyReductionMDP.jl
@@ -154,7 +154,6 @@ function POMDPs.reward(m::UncertaintyReductionMDP, _, action, state)
     if action == [eox]
         -m.bigM
     else
-        # -state.costs' * m.costs_tradeoff
         -sum(state.costs .* m.costs_tradeoff)
     end
 end


### PR DESCRIPTION
`StaticDesigns.ArrangementMDP` uses a tuple to store the tradeoff costs but both MDPs structs for generative designs used vectors. This PR makes sure that all MDP structs consistently use tuples for the tradeoff costs. Besides being more uniform in design, this is a very minor performance improvement and correctness check, as the length of the tradeoff "vector" cannot be longer than 2.